### PR TITLE
Adding reference field

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,20 @@ bookSchema.plugin(autoIncrement.plugin, {
     incrementBy: 100
 });
 ````
-
 Your first book document would have a `bookId` equal to `100`. Your second book document would have a `bookId` equal to `200`, and so on.
+
+### Want to allow for many counters?
+
+````js
+bookSchema.plugin(autoIncrement.plugin, {
+    model: 'Book',
+    field: 'bookId',
+    reference_field: 'userId',
+    startAt: 100,
+    incrementBy: 100
+});
+````
+This will insert the `userId` for the owner of each book into its own counter, allowing to have a seperate book counter for each user.
 
 ### Want to know the next number coming up?
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Your first book document would have a `bookId` equal to `100`. Your second book 
 bookSchema.plugin(autoIncrement.plugin, {
     model: 'Book',
     field: 'bookId',
-    reference_field: 'userId',
+    referenceField: 'userId',
     startAt: 100,
     incrementBy: 100
 });

--- a/index.js
+++ b/index.js
@@ -88,7 +88,10 @@ exports.plugin = function (schema, options) {
 
   // Declare a function to reset counter at the start value - increment value.
   var resetCount = function (count, callback) {
-    count = count || settings.startAt;
+    if(count.constructor.name == 'Function') {
+      callback = count;
+      count = settings.startAt || 0;
+    }
     IdentityCounter.findOneAndUpdate(
       query,
       { count: count - settings.incrementBy },

--- a/index.js
+++ b/index.js
@@ -15,12 +15,12 @@ exports.initialize = function (connection) {
         model: { type: String, require: true },
         field: { type: String, require: true },
         count: { type: Number, default: 0 },
-        reference_field: { type: String, require: false, default: null },
+        referenceField: { type: String, require: false, default: null },
         reference: { type: mongoose.Schema.Types.Mixed, default: null }
       });
 
       // Create a unique index using the "field" and "model" fields.
-      counterSchema.index({ field: 1, model: 1, reference_field: 1, reference: 1 }, { unique: true, required: true, index: -1 });
+      counterSchema.index({ field: 1, model: 1, referenceField: 1, reference: 1 }, { unique: true, required: true, index: -1 });
 
       // Create model using new schema.
       IdentityCounter = connection.model('IdentityCounter', counterSchema);
@@ -110,9 +110,9 @@ exports.plugin = function (schema, options) {
     if (doc.isNew) {
 
       var query = { model: settings.model, field: settings.field };
-      if(typeof settings.reference_field !== 'undefined' && settings.reference_field) {
-        query['reference_field'] = settings.reference_field;
-        query['reference'] = doc[settings.reference_field];
+      if(typeof settings.referenceField !== 'undefined' && settings.referenceField) {
+        query['referenceField'] = settings.referenceField;
+        query['reference'] = doc[settings.referenceField];
       }
       // Find the counter for this model and the relevant field.
       IdentityCounter.findOne(
@@ -121,9 +121,9 @@ exports.plugin = function (schema, options) {
           if (!counter) {
             // If no counter exists then create one and save it.
             var data = { model: settings.model, field: settings.field, count: settings.startAt - settings.incrementBy };
-            if(typeof settings.reference_field !== 'undefined' && settings.reference_field){
-              data.reference_field = settings.reference_field;
-              data.reference = doc[settings.reference_field];
+            if(typeof settings.referenceField !== 'undefined' && settings.referenceField){
+              data.referenceField = settings.referenceField;
+              data.reference = doc[settings.referenceField];
             }
             counter = new IdentityCounter(data);
             counter.save(function (err) {

--- a/index.js
+++ b/index.js
@@ -14,11 +14,13 @@ exports.initialize = function (connection) {
       counterSchema = new mongoose.Schema({
         model: { type: String, require: true },
         field: { type: String, require: true },
-        count: { type: Number, default: 0 }
+        count: { type: Number, default: 0 },
+        reference_field: { type: String, require: false, default: null },
+        reference: { type: mongoose.Schema.Types.Mixed, default: null }
       });
 
       // Create a unique index using the "field" and "model" fields.
-      counterSchema.index({ field: 1, model: 1 }, { unique: true, required: true, index: -1 });
+      counterSchema.index({ field: 1, model: 1, reference_field: 1, reference: 1 }, { unique: true, required: true, index: -1 });
 
       // Create model using new schema.
       IdentityCounter = connection.model('IdentityCounter', counterSchema);
@@ -69,23 +71,6 @@ exports.plugin = function (schema, options) {
     fields[settings.field].unique = settings.unique
   schema.add(fields);
 
-  // Find the counter for this model and the relevant field.
-  IdentityCounter.findOne(
-    { model: settings.model, field: settings.field },
-    function (err, counter) {
-      if (!counter) {
-        // If no counter exists then create one and save it.
-        counter = new IdentityCounter({ model: settings.model, field: settings.field, count: settings.startAt - settings.incrementBy });
-        counter.save(function () {
-          ready = true;
-        });
-      }
-      else {
-        ready = true;
-      }
-    }
-  );
-
   // Declare a function to get the next counter for the model/schema.
   var nextCount = function (callback) {
     IdentityCounter.findOne({
@@ -123,32 +108,73 @@ exports.plugin = function (schema, options) {
 
     // Only do this if it is a new document (see http://mongoosejs.com/docs/api.html#document_Document-isNew)
     if (doc.isNew) {
+
+      var query = { model: settings.model, field: settings.field };
+      if(typeof settings.reference_field !== 'undefined' && settings.reference_field) {
+        query['reference_field'] = settings.reference_field;
+        query['reference'] = doc[settings.reference_field];
+      }
+      // Find the counter for this model and the relevant field.
+      IdentityCounter.findOne(
+        query,
+        function (err, counter) {
+          if (!counter) {
+            // If no counter exists then create one and save it.
+            var data = { model: settings.model, field: settings.field, count: settings.startAt - settings.incrementBy };
+            if(typeof settings.reference_field !== 'undefined' && settings.reference_field){
+              data.reference_field = settings.reference_field;
+              data.reference = doc[settings.reference_field];
+            }
+            counter = new IdentityCounter(data);
+            counter.save(function (err) {
+              console.error(err);
+              if(!err) {
+                ready = true;
+                save();
+              }
+            });
+          }
+          else {
+            ready = true;
+            save();
+          }
+        }
+      );
+
       // Declare self-invoking save function.
-      (function save() {
+      function save() {
         // If ready, run increment logic.
         // Note: ready is true when an existing counter collection is found or after it is created for the
         // first time.
         if (ready) {
           // check that a number has already been provided, and update the counter to that number if it is
           // greater than the current count
+
           if (typeof doc[settings.field] === 'number') {
+            
+            query['count'] = { $lt: doc[settings.field] };
+
             IdentityCounter.findOneAndUpdate(
               // IdentityCounter documents are identified by the model and field that the plugin was invoked for.
               // Check also that count is less than field value.
-              { model: settings.model, field: settings.field, count: { $lt: doc[settings.field] } },
+              query,
               // Change the count of the value found to the new field value.
               { count: doc[settings.field] },
-              function (err) {
+              function (err, counter) {
                 if (err) return next(err);
                 // Continue with default document save functionality.
                 next();
               }
             );
+
           } else {
+
+            console.log(query);
+
             // Find the counter collection entry for this model and field and update it.
             IdentityCounter.findOneAndUpdate(
               // IdentityCounter documents are identified by the model and field that the plugin was invoked for.
-              { model: settings.model, field: settings.field },
+              query,
               // Increment the count by `incrementBy`.
               { $inc: { count: settings.incrementBy } },
               // new:true specifies that the callback should get the counter AFTER it is updated (incremented).
@@ -168,7 +194,7 @@ exports.plugin = function (schema, options) {
         // the counter collection is ready.
         else
           setTimeout(save, 5);
-      })();
+      };
     }
     // If the document does not have the field we're interested in or that field isn't a number AND the user did
     // not specify that we should increment on updates, then just continue the save without any increment logic.

--- a/index.js
+++ b/index.js
@@ -87,14 +87,15 @@ exports.plugin = function (schema, options) {
   schema.static('nextCount', nextCount);
 
   // Declare a function to reset counter at the start value - increment value.
-  var resetCount = function (callback) {
+  var resetCount = function (count, callback) {
+    count = count || settings.startAt;
     IdentityCounter.findOneAndUpdate(
       query,
-      { count: settings.startAt - settings.incrementBy },
+      { count: count - settings.incrementBy },
       { new: true }, // new: true specifies that the callback should get the updated counter.
       function (err) {
         if (err) return callback(err);
-        callback(null, settings.startAt);
+        callback(null, count);
       }
     );
   };

--- a/test/test.js
+++ b/test/test.js
@@ -92,7 +92,7 @@ describe('mongoose-auto-increment', function () {
       should.not.exist(err);
       results.user1[0].should.have.property('userId', 0);
       results.user2[0].should.have.property('userId', 0);
-      results.user4[0].should.have.property('userId', 1);
+      results.user3[0].should.have.property('userId', 1);
       results.user4[0].should.have.property('userId', 1);
       done();
     }

--- a/test/test.js
+++ b/test/test.js
@@ -61,6 +61,48 @@ describe('mongoose-auto-increment', function () {
 
   });
 
+
+  it('should allow for multiple counters per model via a reference field (Test 1)', function(done) {
+
+    // Arrange
+    var userSchema = new mongoose.Schema({
+      name: String,
+      dept: String,
+      uuid: String
+    });
+
+    userSchema.plugin(autoIncrement.plugin, { model: 'User', field: 'userId', referenceField: 'uuid' });
+
+    var User = connection.model('User', userSchema),
+    user1 = new User({ name: 'Charlie', dept: 'Support', uuid: 'a' }),
+    user2 = new User({ name: 'Charles', dept: 'VP', uuid: 'a' }),
+    user3 = new User({ name: 'Charlene', dept: 'Marketing', uuid: 'b' });
+
+    // Act
+    async.series({
+      user1: function (cb) {
+        user1.save(cb);
+      },
+      user2: function (cb) {
+        user2.save(cb);
+      },
+      user3: function (cb) {
+        user3.save(cb);
+      }
+    }, assert);
+
+    // Assert
+    function assert(err, results) {
+      should.not.exist(err);
+      results.user1[0].should.have.property('userId', 0);
+      results.user2[0].should.have.property('userId', 1);
+      results.user3[0].should.have.property('userId', 0);
+      done();
+    }
+
+  });
+
+
   it('should increment the specified field instead (Test 2)', function(done) {
 
     // Arrange


### PR DESCRIPTION
I needed to be able to have multiple counters for a single model, with the addition of a `reference field` and `reference` value I am able to have, for example, multiple counters for the Books model based on the `userId` of the books owner. Each user then has their own counter, starting at 0.
