### PR TITLE
Added promises to the helper method and a "useNext" function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,23 +1,84 @@
 {
-  "name": "mongoose-auto-increment",
-  "version": "5.0.1",
-  "description": "This plugin allows you to auto-increment any field on any mongoose schema that you wish.",
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/codetunnel/mongoose-auto-increment.git"
+  "_args": [
+    [
+      "mongoose-auto-increment",
+      "/Users/altenorgoncalves/Projects/skyinvest/skyinvest-api"
+    ]
+  ],
+  "_from": "mongoose-auto-increment@latest",
+  "_id": "mongoose-auto-increment@5.0.1",
+  "_inCache": true,
+  "_installable": true,
+  "_location": "/mongoose-auto-increment",
+  "_nodeVersion": "4.2.1",
+  "_npmUser": {
+    "email": "alex.ford@codetunnel.com",
+    "name": "chevex"
   },
+  "_npmVersion": "3.3.8",
+  "_phantomChildren": {},
+  "_requested": {
+    "name": "mongoose-auto-increment",
+    "raw": "mongoose-auto-increment",
+    "rawSpec": "",
+    "scope": null,
+    "spec": "latest",
+    "type": "tag"
+  },
+  "_requiredBy": [
+    "/"
+  ],
+  "_resolved": "https://registry.npmjs.org/mongoose-auto-increment/-/mongoose-auto-increment-5.0.1.tgz",
+  "_shasum": "827e051d9cc371dabe8bff1a704431d341cb79df",
+  "_shrinkwrap": null,
+  "_spec": "mongoose-auto-increment",
+  "_where": "/Users/altenorgoncalves/Projects/skyinvest/skyinvest-api",
+  "author": {
+    "email": "alex.ford@codetunnel.com",
+    "name": "Alex Ford",
+    "url": "Chevex"
+  },
+  "bugs": {
+    "url": "https://github.com/codetunnel/mongoose-auto-increment/issues"
+  },
+  "contributors": [
+    {
+      "email": "nassor@gmail.com",
+      "name": "Nassor Paulino da Silva",
+      "url": "rossan"
+    },
+    {
+      "email": "mkoryak@gmail.com",
+      "name": "Misha Koryak",
+      "url": "mkoryak"
+    },
+    {
+      "name": "Christopher Hiller",
+      "url": "boneskull"
+    },
+    {
+      "name": "tomaskavka",
+      "url": "https://github.com/tomaskavka"
+    }
+  ],
   "dependencies": {
-    "extend": "^3.0.0"
+    "extend": "^3.0.0",
+    "q": "^1.4.1"
   },
-  "peerDependencies": {
-    "mongoose": "^4.1.12"
-  },
+  "description": "This plugin allows you to auto-increment any field on any mongoose schema that you wish.",
   "devDependencies": {
     "async": "*",
     "chai": "*",
     "mocha": "*",
     "mongoose": "^4.1.12"
   },
+  "directories": {},
+  "dist": {
+    "shasum": "827e051d9cc371dabe8bff1a704431d341cb79df",
+    "tarball": "https://registry.npmjs.org/mongoose-auto-increment/-/mongoose-auto-increment-5.0.1.tgz"
+  },
+  "gitHead": "50bd2a642c7565cf0a9f2c368d437b83160ad0a6",
+  "homepage": "https://github.com/codetunnel/mongoose-auto-increment#readme",
   "keywords": [
     "mongoose",
     "plugin",
@@ -33,34 +94,24 @@
     "pureautoinc",
     "mongoose-pureautoinc"
   ],
-  "author": {
-    "name": "Alex Ford (Chevex)",
-    "email": "alex.ford@codetunnel.com",
-    "url": "http://CodeTunnel.com"
-  },
-  "contributors": [
+  "maintainers": [
     {
-      "name": "Nassor Paulino da Silva (rossan)",
-      "email": "nassor@gmail.com"
-    },
-    {
-      "name": "Misha Koryak (mkoryak)",
-      "email": "mkoryak@gmail.com",
-      "url": "http://ExhibitionNest.com"
-    },
-    {
-      "name": "Christopher Hiller (boneskull)",
-      "url": "http://boneskull.github.io/"
-    },
-    {
-      "name": "tomaskavka",
-      "url": "https://github.com/tomaskavka"
+      "email": "Alex.Ford@CodeTunnel.com",
+      "name": "chevex"
     }
   ],
+  "name": "mongoose-auto-increment",
+  "optionalDependencies": {},
+  "peerDependencies": {
+    "mongoose": "^4.1.12"
+  },
+  "readme": "ERROR: No README data found!",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/codetunnel/mongoose-auto-increment.git"
+  },
   "scripts": {
     "test": "node_modules/mocha/bin/mocha"
   },
-  "bugs": {
-    "url": "https://github.com/codetunnel/mongoose-auto-increment/issues"
-  }
+  "version": "5.0.1"
 }


### PR DESCRIPTION
The "useNext " method allows the developer to increase the counter manually and return the new value. It's useful when we want to control when an field should be set to the next available indentity. Aditionally an "autoSet" flag has been added to settings in order to allow the developer to bypass the default save functionality. Also, all the methods now return promises and the callbacks for all functions have been made optional.