### PR TITLE
Add upsert true on findOneAndUpdate

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,7 +152,7 @@ exports.plugin = function (schema, options) {
               // Increment the count by `incrementBy`.
               { $inc: { count: settings.incrementBy } },
               // new:true specifies that the callback should get the counter AFTER it is updated (incremented).
-              { new: true },
+              { new: true, upsert: true },
               // Receive the updated counter.
               function (err, updatedIdentityCounter) {
                 if (err) return next(err);


### PR DESCRIPTION
When i use mongoose-auto-increment with my test fonctionnal. I  drop DB after all test. So the collection identitycounter must be recreated if it not exist.