### PR TITLE
Fixing Schema#index() call

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ exports.initialize = function (connection) {
       });
 
       // Create a unique index using the "field" and "model" fields.
-      counterSchema.index({ field: 1, model: 1 }, { unique: true, required: true, index: -1 });
+      counterSchema.index({ field: 1, model: 1 }, { unique: true });
 
       // Create model using new schema.
       IdentityCounter = connection.model('IdentityCounter', counterSchema);


### PR DESCRIPTION
The second parameter of Schema#index() call is passed to MongoDB API and index creation options but neither `required` or `index` is a valid option so I removed both.
Fixing bugs:
https://github.com/chevex-archived/mongoose-auto-increment/issues/76
https://github.com/chevex-archived/mongoose-auto-increment/issues/74