### PR TITLE
fix(MongoError): mongodb-core.lib:error in Function.MongoError.create

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ exports.initialize = function (connection) {
       });
 
       // Create a unique index using the "field" and "model" fields.
-      counterSchema.index({ field: 1, model: 1 }, { unique: true, required: true, index: -1 });
+      counterSchema.index({ field: 1, model: 1 }, { unique: true, index: -1 });
 
       // Create model using new schema.
       IdentityCounter = connection.model('IdentityCounter', counterSchema);


### PR DESCRIPTION
The field 'required' is not valid for an index specification. Specification: { ns: "data.identitycounters", key: { field: 1, model: 1 }, name: "field_1_model_1", unique: true, required: true, index: -1, background: true }