### PR TITLE
Do not remove existing field parameters of schema

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,10 +61,10 @@ exports.plugin = function (schema, options) {
     throw new Error("model must be set");
 
   // Add properties for field in schema.
-  fields[settings.field] = {
+  fields[settings.field] = Object.assign({
     type: Number,
     require: true
-  };
+  }, schema.tree[settings.field]);
   if (settings.field !== '_id')
     fields[settings.field].unique = settings.unique
   schema.add(fields);


### PR DESCRIPTION
At this moment mongoose-auto-increment replaces all settings of a field with new object which could not be an behavior that is expected.
For instance this breaks mongoosastic functionality by "removing" es_indexed and other existing properties, which leave this field unindexed.