### PR TITLE
Allow to specify custom collection name

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,9 +5,10 @@ counterSchema,
 IdentityCounter;
 
 // Initialize plugin by creating counter collection in database.
-exports.initialize = function (connection) {
+exports.initialize = function (connection, modelName) {
+  modelName = modelName || 'IdentityCounter'
   try {
-    IdentityCounter = connection.model('IdentityCounter');
+    IdentityCounter = connection.model(modelName);
   } catch (ex) {
     if (ex.name === 'MissingSchemaError') {
       // Create new counter schema.
@@ -21,7 +22,7 @@ exports.initialize = function (connection) {
       counterSchema.index({ field: 1, model: 1 }, { unique: true, required: true, index: -1 });
 
       // Create model using new schema.
-      IdentityCounter = connection.model('IdentityCounter', counterSchema);
+      IdentityCounter = connection.model(modelName, counterSchema);
     }
     else
       throw ex;


### PR DESCRIPTION
It would be handy if the name of the collection of the counter used by this plugin could be customized.

The default collection name is "identitycounter", however, sometimes this name may conflicts with others or be inconsistent with other naming conventions.

This commit let the caller of the "initialize" function be able to optionally pass her/his desired of the default collection. 

Hope this helps : )